### PR TITLE
Assign CPU resources as a string

### DIFF
--- a/pods/pod.yml
+++ b/pods/pod.yml
@@ -14,4 +14,4 @@ spec:
     resources:
       limits:
         memory: 256Mi
-        cpu: 0.5
+        cpu: "0.5"


### PR DESCRIPTION
The YAML file can't properly distinguish whether 0.5 is a floating point number or a string. By wrapping it in quotes it is unambiguous.

https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/